### PR TITLE
Fixed ApplicationController

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -17,10 +17,6 @@ dependencies:
     github: mosop/teeplate
     version: ~> 0.10.1
 
-  jasper_helpers:
-    github: amberframework/jasper-helpers
-    version: ~> 0.2.5
-
 development_dependencies:
   granite:
     github: amberframework/granite

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -23,7 +23,7 @@ class HTTP::Server::Context
   property current_user : User?
 end
 
-class Mochi::Controllers::ApplicationController < Amber::Controller::Base
+class ApplicationController < Amber::Controller::Base
   # Mock render method
   def render(path)
     true

--- a/src/mochi/controllers/application_controller.cr
+++ b/src/mochi/controllers/application_controller.cr
@@ -1,14 +1,10 @@
-require "jasper_helpers"
 require "amber"
 
 # Main Controller for Amber. All other controller inherit from here.
-# This is a complete clone of ambers `ApplicationController` after generating
-# the auth template.
-class Mochi::Controllers::ApplicationController < Amber::Controller::Base
-  # Includes all view helper methods
-  include JasperHelpers
-  LAYOUT = "application.ecr"
-
+# This opens up the class to insert this method
+#
+# Due to the way Amber initializers work, we need this here to ensure the compiler can find this class before it finds classes trying to inherit from it
+class ApplicationController < Amber::Controller::Base
   # Returns the current_user.
   def current_user
     context.current_user

--- a/src/mochi/controllers/invitable_controller.cr
+++ b/src/mochi/controllers/invitable_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::InvitableController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::InvitableController < ApplicationController
   getter user = User.new
 
   def new

--- a/src/mochi/controllers/omniauthable/granite_session_controller.cr
+++ b/src/mochi/controllers/omniauthable/granite_session_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::Omniauthable::Granite::SessionController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::Omniauthable::Granite::SessionController < ApplicationController
   def create
     redirect_to Mochi::Omniauthable::Provider.authorize_uri(params[:provider], "#{Amber.settings.host}/omniauth/#{params[:provider]}/callback")
   end

--- a/src/mochi/controllers/omniauthable/jennifer_session_controller.cr
+++ b/src/mochi/controllers/omniauthable/jennifer_session_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::Omniauthable::Jennifer::SessionController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::Omniauthable::Jennifer::SessionController < ApplicationController
   def create
     redirect_to Mochi::Omniauthable::Provider.authorize_uri(params[:provider], "#{Amber.settings.host}/omniauth/#{params[:provider]}/callback")
   end

--- a/src/mochi/controllers/omniauthable/user_controller.cr
+++ b/src/mochi/controllers/omniauthable/user_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::Omniauthable::UserController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::Omniauthable::UserController < ApplicationController
   def create
     redirect_to Mochi::Omniauthable::Provider.authorize_uri(params[:provider], "#{Amber.settings.host}/omniauth/user/#{params[:provider]}/callback")
   end

--- a/src/mochi/controllers/password_controller.cr
+++ b/src/mochi/controllers/password_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::PasswordController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::PasswordController < ApplicationController
   getter user = User.new
 
   def new

--- a/src/mochi/controllers/registration_controller.cr
+++ b/src/mochi/controllers/registration_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::RegistrationController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::RegistrationController < ApplicationController
   def confirm(user)
     return redirect_to "/", flash: {"danger" => "Invalid authenticity token."} if user.nil?
 

--- a/src/mochi/controllers/session_controller.cr
+++ b/src/mochi/controllers/session_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::SessionController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::SessionController < ApplicationController
   getter user = User.new
 
   def new

--- a/src/mochi/controllers/unlock_controller.cr
+++ b/src/mochi/controllers/unlock_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::UnlockController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::UnlockController < ApplicationController
   def update(user)
     return redirect_to "/", flash: {"danger" => "Invalid authenticity token."} if user.nil?
 

--- a/src/mochi/controllers/user_controller.cr
+++ b/src/mochi/controllers/user_controller.cr
@@ -1,4 +1,4 @@
-class Mochi::Controllers::UserController < Mochi::Controllers::ApplicationController
+class Mochi::Controllers::UserController < ApplicationController
   getter user = User.new
 
   before_action do


### PR DESCRIPTION
Due to mochi's namespacing, ApplicationController wasn't the same as Amber's ApplicationController. JasperHelpers was also removed as a dependency.